### PR TITLE
Use `@moduledoc` Metadata for NervesTips

### DIFF
--- a/examples/package_a/.formatter.exs
+++ b/examples/package_a/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/examples/package_a/.gitignore
+++ b/examples/package_a/.gitignore
@@ -1,0 +1,23 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+package_a-*.tar
+
+# Temporary files, for example, from tests.
+/tmp/

--- a/examples/package_a/README.md
+++ b/examples/package_a/README.md
@@ -1,0 +1,1 @@
+# PackageA

--- a/examples/package_a/lib/package_a.ex
+++ b/examples/package_a/lib/package_a.ex
@@ -1,0 +1,18 @@
+defmodule PackageA do
+  @moduledoc """
+  Documentation for `PackageA`.
+  """
+
+  @doc """
+  Hello world.
+
+  ## Examples
+
+      iex> PackageA.hello()
+      :world
+
+  """
+  def hello do
+    :world
+  end
+end

--- a/examples/package_a/lib/package_a/nerves_tips.ex
+++ b/examples/package_a/lib/package_a/nerves_tips.ex
@@ -1,0 +1,19 @@
+defmodule PackageA.NervesTips do
+  @moduledoc """
+  Tips provided by PackageA.
+  """
+
+  @moduledoc nerves_tips: [
+    %{
+      text: "Need to write to disk? Store your settings under `/data`.",
+      level: "beginner",
+      topic: "PackageA.Tips"
+    },
+    %{
+      text: "Use `Nerves.Runtime.validate_firmware/0` to check for corruption.",
+      level: "intermediate",
+      topic: "PackageA.Tips"
+    }
+  ]
+end
+

--- a/examples/package_a/mix.exs
+++ b/examples/package_a/mix.exs
@@ -1,0 +1,25 @@
+defmodule PackageA.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :package_a,
+      version: "0.1.0",
+      elixir: "~> 1.18",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  # Run "mix help compile.app" to learn about applications.
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    []
+  end
+end

--- a/examples/package_a/priv/nerves_tips.json
+++ b/examples/package_a/priv/nerves_tips.json
@@ -1,0 +1,7 @@
+[
+  {
+    "text": "Need to write to disk? Store your settings under `/data`.",
+    "level": "beginner",
+    "topic": "package_a"
+  }
+]

--- a/examples/package_a/test/package_a_test.exs
+++ b/examples/package_a/test/package_a_test.exs
@@ -1,0 +1,8 @@
+defmodule PackageATest do
+  use ExUnit.Case
+  doctest PackageA
+
+  test "greets the world" do
+    assert PackageA.hello() == :world
+  end
+end

--- a/examples/package_a/test/test_helper.exs
+++ b/examples/package_a/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/examples/package_b/.formatter.exs
+++ b/examples/package_b/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/examples/package_b/.gitignore
+++ b/examples/package_b/.gitignore
@@ -1,0 +1,23 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+package_b-*.tar
+
+# Temporary files, for example, from tests.
+/tmp/

--- a/examples/package_b/README.md
+++ b/examples/package_b/README.md
@@ -1,0 +1,1 @@
+# PackageB

--- a/examples/package_b/lib/package_b.ex
+++ b/examples/package_b/lib/package_b.ex
@@ -1,0 +1,18 @@
+defmodule PackageB do
+  @moduledoc """
+  Documentation for `PackageB`.
+  """
+
+  @doc """
+  Hello world.
+
+  ## Examples
+
+      iex> PackageB.hello()
+      :world
+
+  """
+  def hello do
+    :world
+  end
+end

--- a/examples/package_b/lib/package_b/nerves_tips.ex
+++ b/examples/package_b/lib/package_b/nerves_tips.ex
@@ -1,0 +1,18 @@
+defmodule PackageB.NervesTips do
+  @moduledoc """
+  Tips provided by PackageB.
+  """
+
+  @moduledoc nerves_tips: [
+    %{
+      text: "Nerves uses a hardware watchdog to recover from hangs.",
+      level: "advanced",
+      topic: "PackageB.Tips"
+    },
+    %{
+      text: "For faster boot times, minimize dependencies in your firmware.",
+      level: "intermediate",
+      topic: "PackageB.Tips"
+    }
+  ]
+end

--- a/examples/package_b/mix.exs
+++ b/examples/package_b/mix.exs
@@ -1,0 +1,25 @@
+defmodule PackageB.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :package_b,
+      version: "0.1.0",
+      elixir: "~> 1.18",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  # Run "mix help compile.app" to learn about applications.
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    []
+  end
+end

--- a/examples/package_b/priv/nerves_tips.json
+++ b/examples/package_b/priv/nerves_tips.json
@@ -1,0 +1,7 @@
+[
+  {
+    "text": "Nerves uses a hardware watchdog to recover from hangs.",
+    "level": "advanced",
+    "topic": "package_b"
+  }
+]

--- a/examples/package_b/test/package_b_test.exs
+++ b/examples/package_b/test/package_b_test.exs
@@ -1,0 +1,8 @@
+defmodule PackageBTest do
+  use ExUnit.Case
+  doctest PackageB
+
+  test "greets the world" do
+    assert PackageB.hello() == :world
+  end
+end

--- a/examples/package_b/test/test_helper.exs
+++ b/examples/package_b/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/examples/sample_app/.formatter.exs
+++ b/examples/sample_app/.formatter.exs
@@ -1,0 +1,4 @@
+# Used by "mix format"
+[
+  inputs: ["{mix,.formatter}.exs", "{config,lib,test}/**/*.{ex,exs}"]
+]

--- a/examples/sample_app/.gitignore
+++ b/examples/sample_app/.gitignore
@@ -1,0 +1,23 @@
+# The directory Mix will write compiled artifacts to.
+/_build/
+
+# If you run "mix test --cover", coverage assets end up here.
+/cover/
+
+# The directory Mix downloads your dependencies sources to.
+/deps/
+
+# Where third-party dependencies like ExDoc output generated docs.
+/doc/
+
+# If the VM crashes, it generates a dump, let's ignore it too.
+erl_crash.dump
+
+# Also ignore archive artifacts (built via "mix archive.build").
+*.ez
+
+# Ignore package tarball (built via "mix hex.build").
+sample_app-*.tar
+
+# Temporary files, for example, from tests.
+/tmp/

--- a/examples/sample_app/README.md
+++ b/examples/sample_app/README.md
@@ -1,0 +1,29 @@
+# SampleApp
+
+SampleApp is a minimal example application demonstrating how `NervesTips`
+discovers and retrieves tips from registered providers.
+
+This app loads tips from `package_a` and `package_b`, both of which opt into
+the `NervesTips` system.
+
+## Setup
+
+```sh
+cd examples/sample_app
+mix deps.get
+```
+
+## Usage
+
+Start an IEx session:
+
+```sh
+iex -S mix
+```
+
+Retrieve tips:
+
+```elixir
+NervesTips.all()    # Get all tips
+NervesTips.random() # Get a random tip
+```

--- a/examples/sample_app/lib/sample_app.ex
+++ b/examples/sample_app/lib/sample_app.ex
@@ -1,0 +1,18 @@
+defmodule SampleApp do
+  @moduledoc """
+  Documentation for `SampleApp`.
+  """
+
+  @doc """
+  Hello world.
+
+  ## Examples
+
+      iex> SampleApp.hello()
+      :world
+
+  """
+  def hello do
+    :world
+  end
+end

--- a/examples/sample_app/mix.exs
+++ b/examples/sample_app/mix.exs
@@ -1,0 +1,29 @@
+defmodule SampleApp.MixProject do
+  use Mix.Project
+
+  def project do
+    [
+      app: :sample_app,
+      version: "0.1.0",
+      elixir: "~> 1.18",
+      start_permanent: Mix.env() == :prod,
+      deps: deps()
+    ]
+  end
+
+  # Run "mix help compile.app" to learn about applications.
+  def application do
+    [
+      extra_applications: [:logger]
+    ]
+  end
+
+  # Run "mix help deps" to learn about dependencies.
+  defp deps do
+    [
+      {:nerves_tips, path: "../.."},
+      {:package_a, path: "../package_a"},
+      {:package_b, path: "../package_b"},
+    ]
+  end
+end

--- a/examples/sample_app/test/sample_app_test.exs
+++ b/examples/sample_app/test/sample_app_test.exs
@@ -1,0 +1,8 @@
+defmodule SampleAppTest do
+  use ExUnit.Case
+  doctest SampleApp
+
+  test "greets the world" do
+    assert SampleApp.hello() == :world
+  end
+end

--- a/examples/sample_app/test/test_helper.exs
+++ b/examples/sample_app/test/test_helper.exs
@@ -1,0 +1,1 @@
+ExUnit.start()

--- a/lib/nerves_tips.ex
+++ b/lib/nerves_tips.ex
@@ -1,7 +1,49 @@
 defmodule NervesTips do
   @moduledoc """
-  Nerves Tips
+  NervesTips provides a simple interface for retrieving useful tips from registered providers.
 
-  Run `Fortune.random!/0` to get a tip!
+  This module automatically discovers available tip providers across loaded applications,
+  aggregates their tips, and provides functions to fetch them.
   """
+
+  @type tip :: %{required(String.t()) => any}
+
+  @doc """
+  Retrieves all available tips from discovered provider modules.
+  """
+  @spec all() :: [tip]
+  def all do
+    discover_provider_modules()
+    |> Enum.flat_map(&fetch_tips_from_metadata/1)
+  end
+
+  @doc """
+  Returns a random tip from the available tips.
+  """
+  @spec random() :: tip
+  def random do
+    all() |> Enum.random()
+  end
+
+  @doc """
+  Discovers provider modules that contain tips in `@moduledoc` metadata.
+
+  This function scans all loaded applications, constructs module names
+  following the `AppName.NervesTips` naming convention.
+  """
+  @spec discover_provider_modules() :: [module]
+  def discover_provider_modules do
+    :application.loaded_applications()
+    |> Enum.map(fn {app, _, _} ->
+      Module.concat([Macro.camelize(Atom.to_string(app)), "NervesTips"])
+    end)
+    |> Enum.filter(&Code.ensure_loaded?/1)
+  end
+
+  defp fetch_tips_from_metadata(mod) do
+    case Code.fetch_docs(mod) do
+      {_, _, _, _, _, %{nerves_tips: tips}, _} -> tips
+      _ -> []
+    end
+  end
 end

--- a/mix.exs
+++ b/mix.exs
@@ -7,7 +7,6 @@ defmodule NervesTips.MixProject do
       version: "0.1.0",
       elixir: "~> 1.11",
       start_permanent: Mix.env() == :prod,
-      compilers: Mix.compilers() ++ [:fortune_compiler],
       deps: deps()
     ]
   end
@@ -18,7 +17,6 @@ defmodule NervesTips.MixProject do
 
   defp deps do
     [
-      {:fortune, "~> 0.1"}
     ]
   end
 end

--- a/mix.lock
+++ b/mix.lock
@@ -1,3 +1,0 @@
-%{
-  "fortune": {:hex, :fortune, "0.1.1", "6aa5a891082bdb0140405935c6d2bbd991809b17080926be0c1ed6f3a4d74adf", [:mix], [], "hexpm", "4c0ed2aef8e7c9029b40fb45dd1cbce65e87ad0dc82fa56938ee1738720e4fdd"},
-}

--- a/test/nerves_tips_test.exs
+++ b/test/nerves_tips_test.exs
@@ -1,8 +1,4 @@
 defmodule NervesTipsTest do
   use ExUnit.Case
   doctest NervesTips
-
-  test "greets the world" do
-    assert NervesTips.hello() == :world
-  end
 end


### PR DESCRIPTION
### Summary

This PR refactors `NervesTips` to use `@moduledoc` metadata for storing and retrieving tips. This simplifies implementation, removes an external dependency, and integrates seamlessly with Elixir's built-in tooling.  

With `Code.fetch_docs/1`, tips are automatically discovered from loaded applications without needing extra compilers or external storage. This keeps things simple while ensuring that:  
- Tips are included in `.beam` files but stripped in production, so they don’t add unnecessary bloat.  
- They don’t clutter ExDoc output, unlike admonition blocks.  
- Metadata like difficulty levels can be added easily for better organization.  

### Changes

- **Replaced `elixir-fortune` with `@moduledoc` metadata**  
  - Tips are now defined within `@moduledoc` using structured metadata.
  - Retrieved using `Code.fetch_docs/1`, eliminating the need for a compiler.
  
- **Updated `NervesTips` module**  
  - Implements `all/0` and `random/0` functions to collect tips from all loaded applications dynamically.

- **Added example packages (`sample_app`, `package_a`, `package_b`)**  
  - `package_a` and `package_b provide their own `NervesTips` module with example tips.
  - `sample_app` demonstrates how any Elixir package can opt into the NervesTips system.

- **Removed `fortune` dependency**  
  - No longer requires a separate compiler or external storage for tips.
